### PR TITLE
Fix open set capacity being altered by node size

### DIFF
--- a/Assets/Scripts/PathFindiningSystem.cs
+++ b/Assets/Scripts/PathFindiningSystem.cs
@@ -206,7 +206,7 @@ namespace PathFinding
 					dstPosition = currentRequest.dst,
 					grid = grid.Copy(Allocator.TempJob),
 					result = new NativeList<int2>(Allocator.TempJob),
-					open = new NativeBinaryHeap<ProcessPathJob.NodeCost>((int)(grid.width * grid.height / (grid.nodeSize) / 2), Allocator.TempJob),
+					open = new NativeBinaryHeap<ProcessPathJob.NodeCost>((int)(grid.width * grid.height), Allocator.TempJob),
 					closed = new NativeHashMap<int2, ProcessPathJob.NodeCost>(128, Allocator.TempJob)
 				};
 				jobHandle = job.Schedule();


### PR DESCRIPTION
Fixed an issue where ProcessPathJob().open's initial capacity took into account the node size of the grid, which would result in the failure of a path with high node sizes. The initial capacity should now reflect the amount of nodes within a grid.